### PR TITLE
Enable project modal in MasonryGrid

### DIFF
--- a/src/components/gallery/MasonryGrid.tsx
+++ b/src/components/gallery/MasonryGrid.tsx
@@ -31,6 +31,7 @@ export default function MasonryGrid({ projects }: MasonryGridProps) {
             whileInView={{ opacity: 1, scale: 1 }}
             viewport={{ once: true }}
             className="relative overflow-hidden rounded-lg shadow-lg group"
+            onClick={() => setSelectedProject(project)}
           >
             <div className="relative h-80">
               <Image

--- a/src/components/gallery/__tests__/MasonryGrid.test.tsx
+++ b/src/components/gallery/__tests__/MasonryGrid.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import MasonryGrid from '../MasonryGrid';
+
+describe('MasonryGrid Component', () => {
+  test('opens detail modal when a project is clicked', async () => {
+    const user = userEvent.setup();
+    const projects = [
+      {
+        id: 1,
+        title: 'Sample Project',
+        description: 'Short description',
+        category: 'Category',
+        image: '/image1.jpg',
+        details: 'Detailed information',
+        dimensions: '10x10'
+      }
+    ];
+
+    render(<MasonryGrid projects={projects} />);
+    expect(screen.queryByText('Detailed information')).not.toBeInTheDocument();
+
+    const image = screen.getByAltText('Sample Project');
+    await user.click(image);
+
+    expect(screen.getByText('Detailed information')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- open project modal on card click in gallery's MasonryGrid
- test that clicking a card opens the detail modal

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f463215cc8326a8e3169a044a819a