### PR TITLE
Remove unused state from Navbar

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -13,7 +13,6 @@ const navigation = [
 ];
 
 export default function Navbar() {
-  const [isOpen, setIsOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const pathname = usePathname();
@@ -36,7 +35,7 @@ export default function Navbar() {
   
   // Close mobile menu when route changes
   useEffect(() => {
-    setIsOpen(false);
+    setIsMenuOpen(false);
   }, [pathname]);
 
   const openMenu = () => {


### PR DESCRIPTION
## Summary
- drop unused `isOpen` state from `Navbar`
- close the mobile menu using `isMenuOpen` on route changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f4630ae748326b7ffbc9b7e039a27