### PR TITLE
Improve site performance

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,6 +38,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={`${playfair.variable} ${inter.variable} scroll-smooth`}>
+      <head>
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+      </head>
       <body className="font-sans bg-background-light text-text-light flex flex-col min-h-screen">
         {/* Skip to content link for accessibility */}
         <a 

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -2,7 +2,12 @@
 
 import { motion } from 'framer-motion';
 import Image from 'next/image';
-import MasonryGrid from '@/components/gallery/MasonryGrid';
+import dynamic from 'next/dynamic';
+
+const MasonryGrid = dynamic(() => import('@/components/gallery/MasonryGrid'), {
+  loading: () => <p>Loading gallery...</p>,
+  ssr: false,
+});
 
 const projects = [
   {


### PR DESCRIPTION
## Summary
- preconnect to Google Fonts for faster font loading
- load gallery grid asynchronously to cut initial JS bundle size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f53af68ac832689850acdd2aa1cab