### PR TITLE
Fix test warnings with updated mocks

### DIFF
--- a/src/components/gallery/__tests__/MasonryGrid.test.tsx
+++ b/src/components/gallery/__tests__/MasonryGrid.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import MasonryGrid from '../MasonryGrid';
@@ -23,8 +23,10 @@ describe('MasonryGrid Component', () => {
     expect(screen.queryByText('Detailed information')).not.toBeInTheDocument();
 
     const image = screen.getByAltText('Sample Project');
-    await user.click(image);
-
+    await act(async () => {
+      await user.click(image);
+    });
+    await screen.findByText('Detailed information');
     expect(screen.getByText('Detailed information')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- filter Next.js image props in test mocks
- ignore framer-motion transition props in test mocks
- await MasonryGrid clicks within `act`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f5d6e881c83268b4b2ea49acb0ec8